### PR TITLE
Modification to the discover command to print a message teaching how to use it if the command is used incorrectly

### DIFF
--- a/commands/discover.py
+++ b/commands/discover.py
@@ -1,11 +1,18 @@
 import os
-import subprocess
 
 def discover(domain, wordlist):
+    if not domain or not wordlist:
+        print("Error: Missing arguments for 'discover'. Usage: discover domain.com -w /path/to/wordlist.txt")
+        return
+
+    if not os.path.isfile(wordlist):
+        print(f"Error: Wordlist file '{wordlist}' not found.")
+        return
+
     output_file = f"/var/tmp/{domain}.txt"
     command = f"gobuster dns -d {domain} -w {wordlist} > /var/tmp/raw_output.txt"
 
-    print(f"Running DNS enum: {command}")
+    print(f"Running DNS enumeration for domain: {domain}")
     os.system(command)
 
     try:
@@ -48,7 +55,7 @@ def discover(domain, wordlist):
                     print(f"Error: Could not open nslookup output file for {subdomain}")
                     continue
 
-        print(f"DNS enumeration and IP resolution complete. Results saved to {output_file}")
+        print(f"DNS enumeration and IP resolution completed. Results saved to {output_file}")
 
     except FileNotFoundError:
         print("Error: Could not open raw output file.")

--- a/main.py
+++ b/main.py
@@ -25,22 +25,25 @@ def main():
 
     while True:
         show_prompt()
-        command = input()
+        command = input().strip()
         args = parse_arguments(command)
 
         if not args:
             continue
 
-        if args[0] == "discover" and len(args) >= 4:
-            domain = args[1]
-            wordlist = args[3]
-            discover(domain, wordlist)
+        if args[0] == "discover":
+            if len(args) == 4 and args[2] == "-w":
+                domain = args[1]
+                wordlist = args[3]
+                discover(domain, wordlist)
+            else:
+                print("Incorrect command. Usage: discover domain.com -w /path/to/wordlist.txt")
         elif args[0] in commands:
             commands[args[0]]()
             if args[0] == "exit":
                 break
-        elif command:
-            os.system(command)
+        else:
+            print(f"Unknown command: {command}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Modification to the discover command so that if the user does not use the command correctly, the code prints "Incorrect command. Usage: discover domain.com -w /path/to/wordlist.txt" instead of trying to interpret it through the Linux shell.